### PR TITLE
SwiftDataの全操作に明示的なsave()呼び出しを追加

### DIFF
--- a/Hibito/ViewModels/TodoListViewModel.swift
+++ b/Hibito/ViewModels/TodoListViewModel.swift
@@ -42,6 +42,7 @@ class TodoListViewModel {
     let newOrder = TodoItem.generateNewOrder()
     let newTodo = TodoItem(content: trimmedContent, order: newOrder)
     modelContext.insert(newTodo)
+    try? modelContext.save()
 
     loadTodos()
   }
@@ -50,6 +51,7 @@ class TodoListViewModel {
   /// - Parameter todo: 完了状態を切り替えるTodoアイテム
   func toggleCompletion(for todo: TodoItem) {
     todo.isCompleted.toggle()
+    try? modelContext.save()
     loadTodos()
   }
 
@@ -59,6 +61,7 @@ class TodoListViewModel {
   func deleteTodo(at index: Int) {
     guard index >= 0 && index < todos.count else { return }
     modelContext.delete(todos[index])
+    try? modelContext.save()
     loadTodos()
   }
 
@@ -78,6 +81,7 @@ class TodoListViewModel {
     )
 
     movingItem.order = newOrder
+    try? modelContext.save()
     loadTodos()
   }
 


### PR DESCRIPTION
## Summary
- SwiftDataのすべてのデータ操作後に明示的な`save()`呼び出しを追加
- これによりデータの永続化が確実に行われるようになる

## 変更内容
TodoListViewModelの以下のメソッドに`try? modelContext.save()`を追加:
- `addTodo`: insert後
- `toggleCompletion`: isCompletedプロパティ変更後
- `deleteTodo`: delete後
- `moveTodo`: orderプロパティ変更後

## テスト結果
TodoListViewModelTestsのすべてのテスト（11件）がパスすることを確認済み