### PR TITLE
macOS版のビルドが通るように & macOS設定画面のUI改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ fastlane/test_output
 
 
 .claude/settings.local.json
+.claude/tmp/
 
 # SweetPad
 /buildServer.json

--- a/Hibito/Views/DebugMenuView.swift
+++ b/Hibito/Views/DebugMenuView.swift
@@ -52,24 +52,26 @@
 
         ScrollView {
           LazyVStack(alignment: .leading, spacing: 8) {
-            ForEach(Array(viewModel.todos.enumerated()), id: \.element.id) { index, todo in
+            ForEach(viewModel.todos) { todo in
+
               VStack(alignment: .leading, spacing: 2) {
                 HStack {
-                  Text("[\(index + 1)] \(todo.isCompleted ? "✓" : "×")")
+                  Text("\(todo.isCompleted ? "✓" : "×")")
                     .font(.caption2)
                     .fontWeight(.medium)
                     .foregroundColor(todo.isCompleted ? .green : .red)
 
                   Spacer()
 
-                  Text("order: \(String(format: "%.3f", todo.order))")
+                  Text("order: \(todo.order, specifier: "%.3f")")
                     .font(.caption2)
                     .foregroundColor(.secondary)
                 }
 
-                Text(todo.content.prefix(50) + (todo.content.count > 50 ? "..." : ""))
+                Text(todo.content)
                   .font(.caption2)
                   .lineLimit(2)
+                  .truncationMode(.tail)
                   .foregroundColor(.primary)
 
                 Text(dateFormatter.string(from: todo.createdAt))
@@ -77,7 +79,7 @@
                   .foregroundColor(.secondary)
               }
               .padding(8)
-              .background(Color(UIColor.systemGray6))
+              .background(Color.gray.opacity(0.1))
               .cornerRadius(6)
             }
           }
@@ -85,7 +87,7 @@
         .frame(maxHeight: 200)
       }
       .padding(8)
-      .background(Color(UIColor.systemGray5))
+      .background(Color.gray.opacity(0.2))
       .cornerRadius(8)
     }
 

--- a/Hibito/Views/SettingsView.swift
+++ b/Hibito/Views/SettingsView.swift
@@ -15,7 +15,9 @@ struct SettingsView: View {
               Text("\(hour):00").tag(hour)
             }
           }
-          .pickerStyle(.wheel)
+          #if os(iOS)
+            .pickerStyle(.wheel)
+          #endif
         } header: {
           Text("リセット時間")
         } footer: {
@@ -38,13 +40,23 @@ struct SettingsView: View {
         }
       }
       .navigationTitle("設定")
-      .navigationBarTitleDisplayMode(.inline)
+      #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
       .toolbar {
-        ToolbarItem(placement: .navigationBarTrailing) {
-          Button("完了") {
-            dismiss()
+        #if os(iOS)
+          ToolbarItem(placement: .navigationBarTrailing) {
+            Button("完了") {
+              dismiss()
+            }
           }
-        }
+        #else
+          ToolbarItem(placement: .confirmationAction) {
+            Button("完了") {
+              dismiss()
+            }
+          }
+        #endif
       }
     }
   }

--- a/Hibito/Views/SettingsView.swift
+++ b/Hibito/Views/SettingsView.swift
@@ -79,15 +79,11 @@ struct SettingsView: View {
             .font(.title2)
             .fontWeight(.semibold)
           Spacer()
-          Button("完了") {
-            dismiss()
-          }
-          .buttonStyle(.borderedProminent)
         }
         .padding()
 
         Form {
-          Section("リセット時間") {
+          VStack(alignment: .leading, spacing: 4) {
             HStack {
               Text("リセット時間")
               Spacer()
@@ -103,16 +99,18 @@ struct SettingsView: View {
               .foregroundColor(.secondary)
           }
 
-          Section("データ同期") {
-            Toggle("iCloud同期", isOn: $viewModel.useCloudSync)
+          VStack(alignment: .leading, spacing: 4) {
+            HStack {
+              Toggle("iCloud同期", isOn: $viewModel.useCloudSync)
+            }
             VStack(alignment: .leading, spacing: 4) {
               Text("TODOと設定を複数デバイス間で同期します")
                 .font(.caption)
                 .foregroundColor(.secondary)
               if viewModel.hasCloudSyncSettingChanged {
                 Text("変更を反映するにはアプリを再起動してください")
-                  .foregroundColor(.orange)
                   .font(.caption)
+                  .foregroundColor(.orange)
               }
             }
           }
@@ -120,6 +118,15 @@ struct SettingsView: View {
         .formStyle(.grouped)
 
         Spacer()
+
+        HStack {
+          Spacer()
+          Button("完了") {
+            dismiss()
+          }
+          .buttonStyle(.borderedProminent)
+        }
+        .padding()
       }
       .frame(minWidth: 400, minHeight: 300)
     }

--- a/Hibito/Views/SettingsView.swift
+++ b/Hibito/Views/SettingsView.swift
@@ -7,60 +7,124 @@ struct SettingsView: View {
   )
 
   var body: some View {
-    NavigationStack {
-      Form {
-        Section {
-          Picker("リセット時間", selection: $viewModel.resetTime) {
-            ForEach(0..<24, id: \.self) { hour in
-              Text("\(hour):00").tag(hour)
-            }
-          }
-          #if os(iOS)
-            .pickerStyle(.wheel)
-          #endif
-        } header: {
-          Text("リセット時間")
-        } footer: {
-          Text("毎日\(viewModel.resetTime):00に、それより前に作成されたタスクが自動的に削除されます")
-        }
+    #if os(iOS)
+      SettingsView_iOS(viewModel: viewModel, dismiss: dismiss)
+    #else
+      SettingsView_macOS(viewModel: viewModel, dismiss: dismiss)
+    #endif
+  }
+}
 
-        Section {
-          Toggle("iCloud同期", isOn: $viewModel.useCloudSync)
-        } header: {
-          Text("データ同期")
-        } footer: {
-          VStack(alignment: .leading, spacing: 8) {
-            Text("TODOと設定を複数デバイス間で同期します")
-            if viewModel.hasCloudSyncSettingChanged {
-              Text("変更を反映するにはアプリを再起動してください")
-                .foregroundColor(.orange)
-                .font(.caption)
+// MARK: - iOS Settings View
+#if os(iOS)
+  struct SettingsView_iOS: View {
+    @Bindable var viewModel: SettingsViewModel
+    let dismiss: DismissAction
+
+    var body: some View {
+      NavigationStack {
+        Form {
+          Section {
+            Picker("リセット時間", selection: $viewModel.resetTime) {
+              ForEach(0..<24, id: \.self) { hour in
+                Text("\(hour):00").tag(hour)
+              }
+            }
+            .pickerStyle(.wheel)
+          } header: {
+            Text("リセット時間")
+          } footer: {
+            Text("毎日\(viewModel.resetTime):00に、それより前に作成されたタスクが自動的に削除されます")
+          }
+
+          Section {
+            Toggle("iCloud同期", isOn: $viewModel.useCloudSync)
+          } header: {
+            Text("データ同期")
+          } footer: {
+            VStack(alignment: .leading, spacing: 8) {
+              Text("TODOと設定を複数デバイス間で同期します")
+              if viewModel.hasCloudSyncSettingChanged {
+                Text("変更を反映するにはアプリを再起動してください")
+                  .foregroundColor(.orange)
+                  .font(.caption)
+              }
             }
           }
         }
-      }
-      .navigationTitle("設定")
-      #if os(iOS)
+        .navigationTitle("設定")
         .navigationBarTitleDisplayMode(.inline)
-      #endif
-      .toolbar {
-        #if os(iOS)
+        .toolbar {
           ToolbarItem(placement: .navigationBarTrailing) {
             Button("完了") {
               dismiss()
             }
           }
-        #else
-          ToolbarItem(placement: .confirmationAction) {
-            Button("完了") {
-              dismiss()
-            }
-          }
-        #endif
+        }
       }
     }
   }
-}
+#endif
+
+// MARK: - macOS Settings View
+#if os(macOS)
+  struct SettingsView_macOS: View {
+    @Bindable var viewModel: SettingsViewModel
+    let dismiss: DismissAction
+
+    var body: some View {
+      VStack(spacing: 20) {
+        HStack {
+          Text("設定")
+            .font(.title2)
+            .fontWeight(.semibold)
+          Spacer()
+          Button("完了") {
+            dismiss()
+          }
+          .buttonStyle(.borderedProminent)
+        }
+        .padding()
+
+        Form {
+          Section("リセット時間") {
+            HStack {
+              Text("リセット時間")
+              Spacer()
+              Picker("", selection: $viewModel.resetTime) {
+                ForEach(0..<24, id: \.self) { hour in
+                  Text("\(hour):00").tag(hour)
+                }
+              }
+              .frame(width: 100)
+            }
+            Text("毎日\(viewModel.resetTime):00に、それより前に作成されたタスクが自動的に削除されます")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+
+          Section("データ同期") {
+            Toggle("iCloud同期", isOn: $viewModel.useCloudSync)
+            VStack(alignment: .leading, spacing: 4) {
+              Text("TODOと設定を複数デバイス間で同期します")
+                .font(.caption)
+                .foregroundColor(.secondary)
+              if viewModel.hasCloudSyncSettingChanged {
+                Text("変更を反映するにはアプリを再起動してください")
+                  .foregroundColor(.orange)
+                  .font(.caption)
+              }
+            }
+          }
+        }
+        .formStyle(.grouped)
+
+        Spacer()
+      }
+      .frame(minWidth: 400, minHeight: 300)
+    }
+  }
+#endif
 
 #Preview {
   SettingsView()


### PR DESCRIPTION
## Summary
- macOS版設定画面の完了ボタンを右下に移動
- iOS版との文言統一
- iCloud同期設定の変更メッセージ位置を調整

## 変更内容
- **完了ボタンの位置変更**: タイトル行の右端から画面右下に移動
- **文言統一**: 
  - 「毎日のリセット時刻」→「リセット時間」
  - 説明文の句点削除でiOS版と統一
  - 再起動メッセージをiOS版と同じ文言に変更
- **メッセージ配置**: iCloud同期の変更メッセージを説明文の下に配置

## Test plan
- [x] macOS版設定画面で完了ボタンが右下に表示される
- [x] iOS版との文言が一致している
- [x] iCloud同期設定変更時のメッセージが適切な位置に表示される